### PR TITLE
Maintain one loader for the `load_extensions` session

### DIFF
--- a/lib/conventional_extensions.rb
+++ b/lib/conventional_extensions.rb
@@ -6,7 +6,12 @@ module ConventionalExtensions
   Object.extend self # We're enriching object itself, so any object can call `load_extensions`.
 
   def load_extensions(*extensions)
-    Loader.new(self, caller_locations(1, 1).first.path).load(*extensions)
+    loader_defined_before_entrance = defined?(@loader)
+
+    @loader ||= Loader.new(self, caller_locations(1, 1).first.path)
+    @loader.load(*extensions)
+  ensure
+    @loader = nil unless loader_defined_before_entrance
   end
   alias load_extension load_extensions
 


### PR DESCRIPTION
Fixes #1

If we set a loader on the main entrance to `load_extensions`, any
`load_extension`/`load_extensions` calls from within an extension can
be tracked in a Set so we avoid double-loading.

Essentially, if load_extensions tries to load :first and :second, but
:first includes `load_extension :second` we should omit loading :second
when the original `load_extensions` gets to :second in its
`each { load_one _1 }` loop.

This means we can avoid using `::Kernel.require` and `$LOADED_FEATURES`,
and it should give us better Zeitwerk interop, though I haven't tested
this yet.

Then once we exit the top-level `load_extensions` we can discard the
loader and all its state. Yay GC!