### PR TITLE
Ignore extensions folders in Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Ignore extensions folders automatically in Rails.
+
+  We've added a Railtie which automatically ignores every extensions folder by running `Rails.autoloaders.main.ignore "**/extensions/**.rb"`.
+
+  Fixed #8.
+
 - Remove automatic extension loading for Active Records.
 
   Due to the automatic extension loading in Active Record, there was no way for people to manually call `load_extensions` if they wanted to. And implementation wise there wasn't a way to sort that out. So the automatic loading support is out.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ There are places where concerns are more suited:
 * Multi-model concerns in `app/models/concerns`, you'd need modules to help with that.
 * Needing to include multiple levels of modules and have them all inserted directly on the base class, concerns have this built in, but ConventionalExtensions can't support that. It's a rare use case nonetheless.
 
+## Using with Zeitwerk
+
+If you're using Zeitwerk to eager load your app or lib code, you may need to ignore the nested extensions folders so Zeitwerk won't expect them to contain code following its naming conventions.
+
+We handle this for Rails through `Rails.autoloaders.main.ignore "**/extensions/**.rb"`. Feel free to use this `ignore` call on your Zeitwerk loader.
+
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:

--- a/lib/conventional_extensions.rb
+++ b/lib/conventional_extensions.rb
@@ -31,3 +31,5 @@ module ConventionalExtensions
 
   autoload :Loader, "conventional_extensions/loader"
 end
+
+require_relative "conventional_extensions/railtie" if defined?(Rails::Railtie)

--- a/lib/conventional_extensions/railtie.rb
+++ b/lib/conventional_extensions/railtie.rb
@@ -1,0 +1,5 @@
+class ConventionalExtensions::Railtie < Rails::Railtie
+  initializer "conventional_extensions.ignore_extensions_directories" do
+    Rails.autoloaders.main.ignore "**/extensions/**.rb"
+  end
+end


### PR DESCRIPTION
Fixes #8

Noted the change in the changelog and what other apps need in the readme.